### PR TITLE
Bugfix "EDITORS-94 SEFF Diagram Editor Test"

### DIFF
--- a/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
@@ -6,8 +6,8 @@ Element-Type: testcase
 Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-94
 Id: _yhy4kB75EeizwOOeaV1e7w
-Runtime-Version: 2.2.0.201706152316
-Save-Time: 3/16/18 11:21 AM
+Runtime-Version: 2.3.0.201806262310
+Save-Time: 8/14/18, 5:22 PM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -195,7 +195,6 @@ with [get-editor "new Repository Diagram"] {
         mouse-release 469 42 button1 524288 -height 575 -width 1091
     }
     with [get-diagram -index 1] {
-        get-figure -path "0/1/0/0" | mouse-hover 329 42 -height 575 -width 1091
         with [get-edit-part -name "new Repository Diagram" | get-edit-part -name "<<InfrarstructureInterface>>\n"
             + "InfrastructureInterface2"] {
             mouse-move 85 31 -height 100 -width 200

--- a/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-94
 Id: _yhy4kB75EeizwOOeaV1e7w
 Runtime-Version: 2.3.0.201806262310
-Save-Time: 8/14/18, 5:23 PM
+Save-Time: 8/14/18, 5:28 PM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -216,7 +216,7 @@ with [get-editor "new Repository Diagram"] {
         commit-direct-edit
         key-type Enter
         with [get-edit-part -name "new Repository Diagram"] {
-            with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+            with [get-edit-part -name "<<InfrastructureInterface>>\n"
                 + "IR2" | get-edit-part -className DNodeListViewNodeListCompartment2EditPart] {
                 mouse-move 66 7 -height 61 -width 196
                 mouse-hover 66 7 -height 61 -width 196
@@ -231,7 +231,7 @@ with [get-editor "new Repository Diagram"] {
         }
         get-figure -path "0/1/0/0" | mouse-release 274 55 button1 524288 -height 575 -width 1091
         with [get-edit-part -name "new Repository Diagram"] {
-            with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+            with [get-edit-part -name "<<InfrastructureInterface>>\n"
                 + "IR2" | get-edit-part -className DNodeListViewNodeListCompartment2EditPart] {
                 mouse-move 61 7 button1 -height 61 -width 196
                 mouse-press 61 7 button1 -height 61 -width 196
@@ -276,7 +276,7 @@ with [get-editor "new Repository Diagram"] {
             }
         }
         mouse-move 469 90 -height 575 -width 1091
-        with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+        with [get-edit-part -name "<<InfrastructureInterface>>\n"
             + "IR2"] {
             mouse-move 36 33 -height 100 -width 200
             with [get-edit-part -className DNodeListNameEditPart] {
@@ -287,7 +287,7 @@ with [get-editor "new Repository Diagram"] {
         }
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
-        with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+        with [get-edit-part -name "<<InfrastructureInterface>>\n"
             + "IR2" | get-edit-part -className DNodeListNameEditPart] {
             mouse-release 58 9 button1 524288 -height 26 -width 170
             mouse-hover 58 9 -height 26 -width 170

--- a/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-94 SEFF Diagram Editor Test.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-94
 Id: _yhy4kB75EeizwOOeaV1e7w
 Runtime-Version: 2.3.0.201806262310
-Save-Time: 8/14/18, 5:22 PM
+Save-Time: 8/14/18, 5:23 PM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -195,7 +195,7 @@ with [get-editor "new Repository Diagram"] {
         mouse-release 469 42 button1 524288 -height 575 -width 1091
     }
     with [get-diagram -index 1] {
-        with [get-edit-part -name "new Repository Diagram" | get-edit-part -name "<<InfrarstructureInterface>>\n"
+        with [get-edit-part -name "new Repository Diagram" | get-edit-part -name "<<InfrastructureInterface>>\n"
             + "InfrastructureInterface2"] {
             mouse-move 85 31 -height 100 -width 200
             with [get-edit-part -className DNodeListNameEditPart] {


### PR DESCRIPTION
# Description
### What's included?
This request contains all bugfixes that make "EDITORS-94 SEFF Diagram Editor Test" work.
### What's fixed?
The problem was the misspelling of the word "Infrastructure" in the test script after line 166.
### Other changes
During fixing this test, I found a line containing a mouse-action, that seems to be useless. I removed it.