### PR TITLE
Bugfix "EDITORS-97 System Diagram Editor Test"

### DIFF
--- a/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-97
 Id: _VZFdAB75EeizwOOeaV1e7w
 Runtime-Version: 2.3.0.201806262310
-Save-Time: 8/15/18, 6:40 PM
+Save-Time: 8/16/18, 10:29 AM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -114,21 +114,20 @@ with [get-editor "new Repository Diagram"] {
     
     // Required role BC1 -> IR1
     with [get-palette | get-palette-entry RequiredRole] {
-        mouse-press 0 0 button1 -height 0 -width 0
-        mouse-release 0 0 button1 -height 0 -width 0
+        mouse-press 0 0 button1 -height 26 -width 357
+        mouse-release 0 0 button1 -height 26 -width 357
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
         with [get-edit-part -name "<<BasicComponent>>\n"
             + "BC1"] {
-            mouse-move 180 30 button1
-            mouse-press 180 30 button1
-            mouse-release 180 30 button1
+            mouse-press 0 0 button1 -height 202 -width 179
+            mouse-release 0 0 button1 -height 202 -width 179
         }
         with [get-edit-part -name "<<Interface>>\n"
             + "IR1"] {
-            mouse-move 80 10 button1 -height 60 -width 0
-            mouse-press 80 10 button1 -height 60 -width 0
-            mouse-release 80 10 button1 -height 60 -width 0
+            mouse-move 121 24 button1 -height 59 -width 196
+            mouse-press 0 0 button1
+            mouse-release 0 0 button1
             get-target-connection -path 0 | get-edit-part -className DEdgeNameEditPart | get-property name | equals "<<Requires>> \nBC1.IR1.OperationRequiredRole1" | verify-true
         }
     }

--- a/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-97
 Id: _VZFdAB75EeizwOOeaV1e7w
 Runtime-Version: 2.3.0.201806262310
-Save-Time: 8/16/18, 10:29 AM
+Save-Time: 8/16/18, 10:58 AM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -151,26 +151,25 @@ with [get-editor "new Repository Diagram"] {
         key-type F2
         type-text "IR2"
         mouse-press 0 500 button1 // apply changed name
-        get-edit-part -name "<<InfrarstructureInterface>>\nIR2" | get-property name | equals "<<InfrarstructureInterface>>\nIR2" | verify-true
+        get-edit-part -name "<<InfrastructureInterface>>\nIR2" | get-property name | equals "<<InfrastructureInterface>>\nIR2" | verify-true
     }
     
     // Infrastructure required role BC1 -> IR2
     with [get-palette | get-palette-entry InfrastructureRequiredRole] {
-        mouse-press 0 0 button1 -height 0 -width 0
-        mouse-release 0 0 button1 -height 0 -width 0
+        mouse-press 0 0 button1 -height 26 -width 357
+        mouse-release 0 0 button1 -height 26 -width 357
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
         with [get-edit-part -name "<<BasicComponent>>\n"
             + "BC1"] {
-            mouse-move 180 50 button1
-            mouse-press 180 50 button1
-            mouse-release 180 50 button1
+            mouse-press 0 0 button1 -height 202 -width 179
+            mouse-release 0 0 button1 -height 202 -width 179
         }
-        with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+        with [get-edit-part -name "<<InfrastructureInterface>>\n"
             + "IR2"] {
-            mouse-move 80 10 button1 -height 60 -width 0
-            mouse-press 80 10 button1 -height 60 -width 0
-            mouse-release 80 10 button1 -height 60 -width 0
+            mouse-move 121 24 button1 -height 59 -width 196
+            mouse-press 0 0 button1
+            mouse-release 0 0 button1
             get-target-connection -path 0 | get-edit-part -className DEdgeNameEditPart | get-property name | equals "<<Requires>> \nBC1.IR2.InfrastructureRequiredRole1" | verify-true
         }
     }
@@ -192,21 +191,21 @@ with [get-editor "new Repository Diagram"] {
 
     // Required role CC1 -> IP1
     with [get-palette | get-palette-entry RequiredRole] {
-        mouse-press 0 0 button1 -height 0 -width 0
-        mouse-release 0 0 button1 -height 0 -width 0
+        mouse-press 0 0 button1 -height 26 -width 357
+        mouse-release 0 0 button1 -height 26 -width 357
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
         with [get-edit-part -name "<<CompositeComponent>>\n"
             + "CC1"] {
-            mouse-move 180 10 button1 -height 60 -width 0
-            mouse-press 180 10 button1 -height 60 -width 0
-            mouse-release 180 10 button1 -height 60 -width 0
+            mouse-move 12 30 button1 -height 100 -width 200
+            mouse-press 12 30 button1 -height 100 -width 200
+            mouse-release 12 30 button1 -height 100 -width 200
         }
         with [get-edit-part -name "<<Interface>>\n"
             + "IP1"] {
-            mouse-move 80 10 button1 -height 60 -width 0
-            mouse-press 80 10 button1 -height 60 -width 0
-            mouse-release 80 10 button1 -height 60 -width 0
+            mouse-move 146 26 button1 -height 100 -width 200
+            mouse-press 146 26 button1 -height 100 -width 200
+            mouse-release 146 26 button1 -height 100 -width 200
             get-target-connection -path 1 | get-edit-part -className DEdgeNameEditPart | get-property name | equals "<<Requires>> \nCC1.IP1.OperationRequiredRole1" | verify-true
         }
     }
@@ -223,7 +222,7 @@ with [get-editor "new Repository Diagram"] {
             mouse-press 180 30 button1 -height 60 -width 0
             mouse-release 180 30 button1 -height 60 -width 0
         }
-        with [get-edit-part -name "<<InfrarstructureInterface>>\n"
+        with [get-edit-part -name "<<InfrastructureInterface>>\n"
             + "IR2"] {
             mouse-move 80 10 button1 -height 60 -width 0
             mouse-press 80 10 button1 -height 60 -width 0

--- a/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-97
 Id: _VZFdAB75EeizwOOeaV1e7w
 Runtime-Version: 2.3.0.201806262310
-Save-Time: 8/16/18, 10:58 AM
+Save-Time: 8/16/18, 11:09 AM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -212,21 +212,22 @@ with [get-editor "new Repository Diagram"] {
     
     // Infrastructure provided role CC1 -> IR2
     with [get-palette | get-palette-entry InfrastructureProvidedRole] {
-        mouse-press 0 0 button1 -height 0 -width 0
-        mouse-release 0 0 button1 -height 0 -width 0
+        mouse-press 0 0 button1 -height 26 -width 357
+        mouse-release 0 0 button1 -height 26 -width 357
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
         with [get-edit-part -name "<<CompositeComponent>>\n"
             + "CC1"] {
-            mouse-move 180 30 button1 -height 60 -width 0
-            mouse-press 180 30 button1 -height 60 -width 0
-            mouse-release 180 30 button1 -height 60 -width 0
+            mouse-move 12 30 button1 -height 100 -width 200
+            mouse-press 12 30 button1 -height 100 -width 200
+            mouse-release 12 30 button1 -height 100 -width 200
         }
         with [get-edit-part -name "<<InfrastructureInterface>>\n"
             + "IR2"] {
-            mouse-move 80 10 button1 -height 60 -width 0
-            mouse-press 80 10 button1 -height 60 -width 0
-            mouse-release 80 10 button1 -height 60 -width 0
+            mouse-move 121 24 button1 -height 59 -width 196
+            mouse-press 0 0 button1
+            mouse-release 0 0 button1
+            get-target-connection -path 1 | get-edit-part -className DEdgeNameEditPart | get-property name | equals "<<Provides>> \nCC1.IR2.InfrastructureProvidedRole1" | verify-true
         }
     }
 

--- a/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
+++ b/org.palladiosimulator.product.tests.ui/EDITORS-97 System Diagram Editor Test.test
@@ -6,8 +6,8 @@ Element-Type: testcase
 Element-Version: 3.0
 External-Reference: https://sdqbuild.ipd.kit.edu/jira/browse/EDITORS-97
 Id: _VZFdAB75EeizwOOeaV1e7w
-Runtime-Version: 2.2.0.201706152316
-Save-Time: 5/25/18 4:39 PM
+Runtime-Version: 2.3.0.201806262310
+Save-Time: 8/15/18, 6:40 PM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -76,25 +76,27 @@ with [get-editor "new Repository Diagram"] {
     
     // Provided role BC1 -> IP1
     with [get-palette | get-palette-entry ProvidedRole] {
-        mouse-press 0 0 button1 -height 0 -width 0
-        mouse-release 0 0 button1 -height 0 -width 0
+        mouse-press 0 0 button1 -height 26 -width 357
+        mouse-release 0 0 button1 -height 26 -width 357
     }
     with [get-diagram -index 1 | get-edit-part -name "new Repository Diagram"] {
+        // set role startpoint
         with [get-edit-part -name "<<BasicComponent>>\n"
             + "BC1"] {
-            mouse-move 180 10 button1
-            mouse-press 180 10 button1
-            mouse-release 180 10 button1
+            mouse-press 0 0 button1 -height 202 -width 179
+            mouse-release 0 0 button1 -height 202 -width 179
         }
+        // set role endpoint and verify it
         with [get-edit-part -name "<<Interface>>\n"
             + "IP1"] {
-            mouse-move 80 10 button1 -height 60 -width 0
-            mouse-press 80 10 button1 -height 60 -width 0
-            mouse-release 80 10 button1 -height 60 -width 0
+            // set role endpoint
+            mouse-move 121 24 button1 -height 59 -width 196
+            mouse-press 0 0 button1
+            mouse-release 0 0 button1
+            // verify role present
             get-target-connection -path 0 | get-edit-part -className DEdgeNameEditPart | get-property name | equals "<<Provides>> \nBC1.IP1.OperationProvidedRole1" | verify-true
         }
     }
-    
     // IR1 interface
     with [get-palette | get-palette-entry Interface] {
         mouse-press 0 0 button1 -height 0 -width 0


### PR DESCRIPTION
# Description
## What's included?
This request contains all bugfixes that make "EDITORS-97 System Diagram Editor Test" work.
## What's fixed?
Besides the misspelling of the word "Infrastructure", the main problem of this test were bad mouse-coordinates and mouse-dimensions. Because of them, some roles could not be created, what led in most cases to a stranded, and in some cases to a failed test.
## Other changes
During fixing this test, I found a part where a role had been created, but the result was not verified. I added the missing verification.