### PR TITLE
Use 2.4.0 snapshot version of RCPTT plugin

### DIFF
--- a/org.palladiosimulator.product.tests.ui/pom.xml
+++ b/org.palladiosimulator.product.tests.ui/pom.xml
@@ -16,11 +16,19 @@
       <name>RCPTT Maven repository</name>
       <url>https://repo.eclipse.org/content/repositories/rcptt-releases/</url>
     </pluginRepository>
+    <pluginRepository>
+      <id>rcptt-snapshots</id>
+      <name>RCPTT Maven Snapshots repository</name>
+      <snapshots>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+      <url>https://repo.eclipse.org/content/repositories/rcptt-snapshots/</url>
+    </pluginRepository>
   </pluginRepositories>
 
   <properties>
 	<examples.dir>${project.build.directory}/examples</examples.dir>
-    <rcptt-maven-version>2.2.0</rcptt-maven-version>
+    <rcptt-maven-version>2.4.0-SNAPSHOT</rcptt-maven-version>
   </properties>
 
   <build>


### PR DESCRIPTION
We are facing build errors because all stable versions of the RCPTT plugin for maven cannot properly start a photon based Eclipse instance. Therefore, I switched to the latest snapshot version that works with the latest PCM drops.